### PR TITLE
Let the build system detect preferred host OpenCV video capture API

### DIFF
--- a/calico/CMakeLists.txt
+++ b/calico/CMakeLists.txt
@@ -22,4 +22,13 @@ find_package(OpenCV CONFIG REQUIRED)
 file(GLOB DATA_TO_COPY "data/*.*")
 file(COPY ${DATA_TO_COPY} DESTINATION ${CMAKE_BINARY_DIR}/calico)
 
+if(WIN32)
+  set(cv_cap_api "cv::CAP_DSHOW")
+elseif(LINUX)
+  set(cv_cap_api "cv::CAP_V4L")
+else()
+  set(cv_cap_api "cv::CAP_ANY")
+endif()
+
+target_compile_definitions(${TargetName} PRIVATE CAP_API=${cv_cap_api})
 target_link_libraries(${TargetName} PRIVATE ${SOBJECTIZER_LIB} ${OPENCV_LIBS})

--- a/calico/constants.h
+++ b/calico/constants.h
@@ -1,7 +1,9 @@
 #pragma once
+#include <opencv2/videoio.hpp>
 #include <string>
 
 namespace calico::constants
 {
 	inline const std::string waitkey_channel_name = "waitkey_out";
+	constexpr cv::VideoCaptureAPIs cv_cap_api = CAP_API;
 }

--- a/calico/producers/image_producer_recursive.cpp
+++ b/calico/producers/image_producer_recursive.cpp
@@ -1,9 +1,10 @@
 #include "image_producer_recursive.h"
 #include "../signals.h"
 #include "../errors.h"
+#include "../constants.h"
 
 calico::producers::image_producer_recursive::image_producer_recursive(so_5::agent_context_t ctx, so_5::mbox_t channel, so_5::mbox_t commands)
-	: agent_t(std::move(ctx)), m_channel(std::move(channel)), m_commands(std::move(commands)), m_capture(0, cv::CAP_DSHOW)
+	: agent_t(std::move(ctx)), m_channel(std::move(channel)), m_commands(std::move(commands)), m_capture(0, calico::constants::cv_cap_api)
 {
 }
 


### PR DESCRIPTION
Use CMake's `configure_file()` function to select an Open CV video capture API suitable for the host system.

This is a cleaner and simpler alternative to the nasty `#ifdef` conditional build directive in the source code.